### PR TITLE
Statyczne (dla całej klasy jedno) obliczanie dt +

### DIFF
--- a/FlightController_v1_0/FlightController_v1_0.ino
+++ b/FlightController_v1_0/FlightController_v1_0.ino
@@ -120,7 +120,11 @@ inline void stabilize()
 	sensors.readAngles();
 	sensors.readCompass();
 	
+	// Zaktualizuj dt dla calej klasy PID
+	PID::updateDeltaTime();
+	
 	// headingToHold += odebrany obrot; // do zrobienia !!!
+	//PID::getDeltaTime(); // zwraca dt
 	
 	// PIDy poziomowania
 	int32_t pidX = levelX_PID.get_pid(sensors.angle.pitch);

--- a/FlightController_v1_0/PID.cpp
+++ b/FlightController_v1_0/PID.cpp
@@ -11,25 +11,19 @@
 int32_t
 PID::get_pid(float error)
 {
-    uint32_t tnow = millis();
-    uint32_t dt = tnow - _last_t;
-    float output = 0;
-    float delta_time;
-    _last_t = tnow;
+	float output = 0;
 
-    delta_time = (float)dt * 0.001;
-
-    // Compute proportional component
+	// Compute proportional component
 	float pro = error * _kp;
 	outPro = (int8_t)pro;
-    output += pro;
+	output += pro;
 
     // Compute derivative component if time has elapsed
-    if (dt > 0) // NIE WIEM CZY POTRZEBNE BO I TAK TO SIE WYKONUJE STOSUNKOWO RZADKO !!!
+    if (dt_ms > 0) // NIE WIEM CZY POTRZEBNE BO I TAK TO SIE WYKONUJE STOSUNKOWO RZADKO !!!
 	{
         float derivative;
 
-		derivative = (error - _last_error) / delta_time;
+		derivative = (error - _last_error) / dt_sec;
 
         // discrete low pass filter, cuts out the
         // high frequency noise that can drive the controller crazy
@@ -46,7 +40,7 @@ PID::get_pid(float error)
         output += der;
 
     // Compute integral component
-        _integrator += (error * _ki) * delta_time;
+        _integrator += (error * _ki) * dt_sec;
 		
 		// anti wind-up
 		_integrator = constrain(_integrator, -_imax, _imax);
@@ -65,5 +59,20 @@ PID::reset_I()
 	// we use NAN (Not A Number) to indicate that the last 
 	// derivative value is not valid
     _last_derivative = NAN;
+}
+
+
+uint32_t PID::dt_ms = 0;
+float PID::dt_sec = 0;
+
+
+void PID::updateDeltaTime()
+{
+	static uint32_t _last_t;
+	static uint32_t tnow;
+	tnow = millis();
+	dt_ms = tnow - _last_t;
+	_last_t = tnow;
+	dt_sec = (float)dt_ms * 0.001;
 }
 

--- a/FlightController_v1_0/PID.h
+++ b/FlightController_v1_0/PID.h
@@ -11,7 +11,18 @@
 
 /// @class	PID
 /// @brief	Object managing one PID control
-class PID {
+class PID
+{
+// Statyczne zmienne i metody
+private:
+	static uint32_t dt_ms;  // [ms]
+	static float dt_sec;    // [s]
+	
+public:
+	static void updateDeltaTime(); // Aktualizacja dt dla wszystkich obiektow klasy PID
+	static float getDeltaTime() { return dt_sec; }
+	
+// Reszta kodu
 public:
 
     PID(const float &   initial_p = 0.0,
@@ -50,7 +61,7 @@ public:
     /// @name	parameter accessors
     //@{
 
-
+/*
     float        kP() const {
         return _kp;
     }
@@ -62,35 +73,40 @@ public:
     }
     int16_t        imax() const {
         return _imax;
-    }
+    }*/
 
-    void        kP(const float v)               {
+    void kP(const float v)
+	{
         _kp=v;
     }
-    void        kI(const float v)               {
+    void kI(const float v)
+	{
         _ki=v;
     }
-    void        kD(const float v)               {
+    void kD(const float v)
+	{
         _kd=v;
     }
-    void        imax(const int16_t v)   {
+    void imax(const int16_t v)
+	{
         _imax=abs(v);
     }
-
-    float        get_integrator() const {
+/*
+    float        get_integrator() const
+	{
         return _integrator;
     }
+	*/
 
 private:
-    float        _kp;
-    float        _ki;
-    float        _kd;
-    int16_t        _imax;
+    float _kp;
+    float _ki;
+    float _kd;
+    int16_t _imax;
 
-    float           _integrator;                                ///< integrator value
-    int32_t         _last_error;                                ///< last error for derivative
-    float           _last_derivative;                           ///< last derivative for low-pass filter
-    uint32_t        _last_t;                                    ///< last time get_pid() was called in millis
+    float _integrator;                 ///< integrator value
+    int32_t _last_error;               ///< last error for derivative
+    float _last_derivative;            ///< last derivative for low-pass filter
 
     int32_t         _get_pid(int32_t error, uint16_t dt, float scaler);
 


### PR DESCRIPTION
+ trochę poprawek wizualnych w klasie PID

Teraz dt nie jest osobne dla klażdego obiektu tylko wspólne dla całęj klasy i liczone raz na pętlę. Można też z niego skorzystać używając statycznej metody getDeltaTime()